### PR TITLE
Added paper_intro_url Field and Introduction Page for "Predicting the Longevity" Paper

### DIFF
--- a/_bibliography/references.bib
+++ b/_bibliography/references.bib
@@ -345,6 +345,7 @@
   title = {Large-scale author name disambiguation using approximate network structures},
   journal = {International Conference on Computational Social Science},
   year = {2020},
+  paper_intro_url = {/publications/ic2s2-author-name-disambiguation.html},
   url = {https://scienceofscience.org/assets/pdf/ic2s2-author_name_disambiguation_zeng_and_acuna.pdf},
 }
 
@@ -542,6 +543,5 @@ url={https://doi.org/10.1186/s13326-024-00304-3}
   journal={Humanities and Social Sciences Communications},
   url = {https://arxiv.org/abs/2203.12800},
   year = {2050},
-  code = {https://github.com/LiamLiang/Bias_AI},
   image = {/assets/images/publications/predicting_longevity/figure8_b.png}
 }

--- a/_bibliography/references.bib
+++ b/_bibliography/references.bib
@@ -543,5 +543,6 @@ url={https://doi.org/10.1186/s13326-024-00304-3}
   journal={Humanities and Social Sciences Communications},
   url = {https://arxiv.org/abs/2203.12800},
   year = {2050},
-  image = {/assets/images/publications/predicting_longevity/figure8_b.png}
+  image = {/assets/images/publications/predicting_longevity/figure8_b.png},
+  paper_intro_url = {/publications/predicting-the-longevity-of-resources-shared-in-scientific-publications.html}
 }

--- a/_layouts/bib.html
+++ b/_layouts/bib.html
@@ -21,16 +21,27 @@
 {% assign dataset_url_exists = true %}
 {% endif %}
 
+<!--  Check if entry.paper_intro_url exists -->
+{% assign paper_intro_url_exists = false %}
+{% if entry.paper_intro_url %}
+{% assign paper_intro_url_exists = true %}
+{% endif %}
+  
 
   <!-- Create a span with classes that can be used to filter entries by type, whether they have a press_url, code, or demo, and whether they have a pdf -->
-<span id="{{entry.key}}" class="bib_entry entry_type_{{entry.type}} press_url_exists_{{press_url_exists}} code_exists_{{code_exists}} demo_exists_{{demo_exists}} dataset_exists_{{dataset_url_exists}}">
+<span id="{{entry.key}}" class="bib_entry entry_type_{{entry.type}} press_url_exists_{{press_url_exists}} code_exists_{{code_exists}} demo_exists_{{demo_exists}} dataset_exists_{{dataset_url_exists}} paper_intro_exists_{{paper_intro_url_exists}}">
 
 {% if entry.image %}
-{% if entry.url %}
+{% if entry.paper_intro_url %} 
+<a href="{{entry.paper_intro_url}}" target="_blank"></a>
+{% elsif entry.url %}
 <a href="{{entry.url}}" target="_blank">
   {% endif %}
   <img src="{{ entry.image }}">
-  {% if entry.url %}
+
+  {% if entry.paper_intro_url %} 
+</a>
+  {% elsif entry.url %}
 </a>
 {% endif %}
 {% endif %}
@@ -42,7 +53,7 @@
 <span style="font-weight: 600;">
 {% endif %}{{author.last}}{% if 0 == first_names | size %},{% endif %}
 {% for fn in first_names %}{{ fn | slice: 0 }}{% endfor %}{% if author.last == "Acuna" %}</span>{% endif %}{% if idx < entry.author_array.size %},{% endif %}{% endfor %}{% if entry.year != "2050" %} ({{entry.year}}),{% endif %}{% if entry.year == "2050" %},{% endif %}
-{% if entry.url %}<a href="{{entry.url}}" target="_blank">{% endif %}{{entry.title}}{% if entry.url %}</a>{% endif %}.
+{% if entry.paper_intro_url %} <a href="{{entry.paper_intro_url}}" target="_blank"> {% elsif entry.url %}<a href="{{entry.url}}" target="_blank">{% endif %}{{entry.title}}{% if entry.paper_intro_url %}</a>{% elsif entry.url %}</a>{% endif %}.
 {% if entry.type == "phdthesis" %} [Ph.D. Thesis] {% endif %}
 {% if entry.type == "incollection" %}In {{entry.editor}} (Eds.),{% endif %}
 <em>{{entry.journal}}{{entry.booktitle}}{{entry.school}}</em>{% if entry.volume %}, {{entry.volume}}{% if entry.number %}({{entry.number}}){% endif %}{% endif %}{% if entry.pages %}, {{entry.pages}}

--- a/_pages/publications/predicting-the-longevity-of-resources-shared-in-scientific-publications.md
+++ b/_pages/publications/predicting-the-longevity-of-resources-shared-in-scientific-publications.md
@@ -1,0 +1,194 @@
+---
+# Please refer to YAML documentation for syntax
+
+# leave it as default
+layout: paper
+
+# leave it as default
+toc: false 
+
+# leave it as default
+author_profile: false 
+
+# leave it as default
+masthead: true 
+
+# leave it as default
+classes: wide page__align_center 
+
+# the link to this page, please always keep the "/publications/" and change "ic2s2-author-name-disambiguation/" to the name you like
+permalink: /publications/predicting-the-longevity-of-resources-shared-in-scientific-publications.html
+
+# The title of the web page, it would be overwrited by citation_title if citation_title exists
+title: Predicting the longevity of resources shared in scientific publications
+
+####################################################################################################
+#<!------ start: meta data for Google Scholar, every property start with a "citation_" prefix ######
+####################################################################################################
+# The title of the paper
+citation_title: Predicting the longevity of resources shared in scientific publications
+
+# The author and affilliation of the paper, it is a list of dictionary, please see YAML documentation for syntax 
+# author_affilliation_list:
+#   - citation_author: 'Zeng, Tong'
+#     citation_author_institution:
+#       - 'School of Information Science, Nanjing University, China'
+#       - 'School of Information Studies, Syracuse University, Syracuse, NY, USA'
+#     citation_author_orcid: '0000-0002-5533-8506'
+
+#   - citation_author: 'Acuna, Daniel E.'
+#     citation_author_institution:
+#       - 'School of Information Studies, Syracuse University, Syracuse, NY, USA'
+#     citation_author_orcid: '0000-0002-7765-1595'
+
+# The keywords of the paper, multiple keywords could be specified as a list
+citation_keywords: ['dataset decay','science of science','predictive analytics','reproducibility']
+
+# The abstract of the paper
+citation_abstract: Research has shown that most resources shared in articles (e.g., URLs to code or data) are not kept up to date and mostly disappear from the web after some years (Zeng et al., 2019). Little is known about the factors that differentiate and predict the longevity of these resources. This article explores a range of explanatory features related to the publication venue, authors, references, and where the resource is shared. We analyze an extensive repository of publications and, through web archival services, reconstruct how they looked at different time points. We discover that the most important factors are related to where and how the resource is shared, while surprisingly little consideration is given to the author’s reputation or prestige of the journal. By examining the places where long-lasting resources are shared, we suggest that it is critical to educate researchers on modern sharing technologies. Finally, we discuss implications for reproducibility and acknowledge scientific datasets as first-class citizens of science.
+
+# publisher
+citation_publisher: 
+
+# The year of the paper
+citation_year: 2024
+
+# The date of the paper
+# citation_date: 2020/07/17
+
+# perhaps this is still used in some old implementations
+# citation_publication_date: 2020/07/17
+
+# for the official date of the issue where the article is published
+citation_cover_date: 
+
+# for the online publishing date
+citation_online_date:
+
+# journal title
+citation_journal_title: 
+
+# journal title abbreviation
+citation_journal_abbrev:
+
+# journal issn
+citation_journal_issn:
+
+# series title
+citation_series_title:
+
+# book title
+citation_book_title:
+
+# volume number
+citation_volume:
+
+# issue number
+citation_issue:
+
+# The title of the conference, e.g. International Conference on Asian Digital Libraries
+# citation_conference_title: International Conference on Computational Social Science
+
+# The title of conference proceedings, e.g. The Emergence of Digital Libraries – Research and Practices
+# citation_inbook_title: 
+
+# conference sequence number, e.g. 16
+# citation_conference_sequence_num: 6
+
+# conference abbreviation, e.g. ICADL
+# citation_conference_abbrev: IC2S2
+
+# dissertation institution
+# citation_dissertation_institution:
+
+# the institution of a technical report
+# citation_technical_report_institution:
+
+# technical report number
+# citation_technical_report_number:
+
+
+# isbn
+citation_isbn:
+
+# doi
+# citation_doi: 10.5281/zenodo.4403705
+
+
+#  arxiv id
+citation_arxiv_id:
+
+
+# issn 
+citation_issn:
+
+
+# eIssn 
+citation_eIssn:
+
+
+# pmid 
+citation_pmid:
+
+
+# patent number
+citation_patent_number:
+
+
+# patent country
+citation_patent_country: 
+
+
+# public url
+# citation_public_url: https://doi.org/10.5281/zenodo.4403705
+
+
+# language
+citation_language: english
+
+
+# firstpage number
+citation_firstpage:
+
+
+# lastpage number
+citation_lastpage:
+
+
+# url of the abstract html file
+citation_abstract_html_url:
+
+
+# url of the fulltext html file
+citation_fulltext_html_url:
+
+# The url for pdf file of the paper
+citation_pdf_url: https://arxiv.org/pdf/2203.12800
+
+####################################################################################################
+# end: meta data for Google Scholar ----> 
+####################################################################################################
+
+
+####################################################################################################
+#<!------ start: html snippet for the display of an article ######
+####################################################################################################
+html_citation_author: ['<strong>Acuna, Daniel E.</strong><sup>1,*</sup>', 'Jian Jian<sup>2</sup>', '<strong>Zeng, Tong</strong><sup>3</sup>','Lizhen Liang<sup>4</sup>', 'Han Zhuang<sup>4</sup>']
+html_insitution_list: ['<sup>1</sup>The University of Colorado Boulder','<sup>2</sup>NetApp, Inc.', '<sup>3</sup>Virginia Tech', '<sup>4</sup>Syracuse University']
+####################################################################################################
+# end: html snippet for the display of an article  ----> 
+####################################################################################################
+---
+
+
+
+
+<h2>Full Text</h2>
+Please <a href="https://arxiv.org/pdf/2203.12800"> click here </a>to read the full paper.
+
+
+<h2>Code and Data</h2>
+Please <a href="https://github.com/sciosci/predicting_resource_longevity/"> vist our Github repo </a>for the code and data.
+
+
+


### PR DESCRIPTION
**Summary of Changes:**

1. **Added `paper_intro_url` Field**: 
   - Introduced a `paper_intro_url` field for entries in the bibliography file located at `_bibliography/references.bib`.
   - When both `paper_intro_url` and `url` are provided, `paper_intro_url` will take priority as the hyperlink target when clicking the paper title.

2. **Added a Paper Introduction Page**:
   - Added a dedicated introduction page for the publication titled *"Predicting the Longevity of Resources Shared in Scientific Publications"*.
